### PR TITLE
Favours OpenSSL environment variables: SSL_CERT_FILE and SSL_CERT_DIR

### DIFF
--- a/x509-system/System/X509/Common.hs
+++ b/x509-system/System/X509/Common.hs
@@ -1,0 +1,26 @@
+module System.X509.Common
+  ( withOpenSSLCertEnv
+  )
+where
+
+import Data.Foldable (asum)
+import Data.Maybe (catMaybes)
+import Data.Monoid (mconcat)
+import Data.X509.CertificateStore
+import System.Environment (lookupEnv)
+
+getOpenSslEnvs :: IO (Maybe String)
+getOpenSslEnvs =
+  asum
+    <$> traverse
+      lookupEnv
+      [ "SSL_CERT_FILE",
+        "SSL_CERT_DIR" 
+      ]
+
+withOpenSSLCertEnv :: IO CertificateStore -> IO CertificateStore
+withOpenSSLCertEnv defaultStore = do
+  overrideCertPaths <- getOpenSslEnvs
+  case overrideCertPaths of
+    Nothing -> defaultStore
+    Just certPath -> mconcat . catMaybes <$> mapM readCertificateStore [certPath]

--- a/x509-system/System/X509/MacOS.hs
+++ b/x509-system/System/X509/MacOS.hs
@@ -10,6 +10,7 @@ import Data.Either
 
 import Data.X509
 import Data.X509.CertificateStore
+import System.X509.Common (withOpenSSLCertEnv)
 
 rootCAKeyChain :: FilePath
 rootCAKeyChain = "/System/Library/Keychains/SystemRootCertificates.keychain"
@@ -26,4 +27,4 @@ listInKeyChains keyChains = do
     return targets
 
 getSystemCertificateStore :: IO CertificateStore
-getSystemCertificateStore = makeCertificateStore <$> listInKeyChains [rootCAKeyChain, systemKeyChain]
+getSystemCertificateStore = withOpenSSLCertEnv (makeCertificateStore <$> listInKeyChains [rootCAKeyChain, systemKeyChain])

--- a/x509-system/System/X509/Unix.hs
+++ b/x509-system/System/X509/Unix.hs
@@ -17,6 +17,7 @@ module System.X509.Unix
     ) where
 
 import System.Environment (getEnv)
+import System.X509.Common (withOpenSSLCertEnv)
 import Data.X509.CertificateStore
 
 import Control.Applicative ((<$>))
@@ -37,7 +38,7 @@ envPathOverride :: String
 envPathOverride = "SYSTEM_CERTIFICATE_PATH"
 
 getSystemCertificateStore :: IO CertificateStore
-getSystemCertificateStore = mconcat . catMaybes <$> (getSystemPaths >>= mapM readCertificateStore)
+getSystemCertificateStore = withOpenSSLCertEnv (mconcat . catMaybes <$> (getSystemPaths >>= mapM readCertificateStore))
 
 getSystemPaths :: IO [FilePath]
 getSystemPaths = E.catch ((:[]) <$> getEnv envPathOverride) inDefault

--- a/x509-system/System/X509/Win32.hs
+++ b/x509-system/System/X509/Win32.hs
@@ -20,6 +20,7 @@ import Data.X509.CertificateStore
 import Data.ASN1.Error
 
 import System.Win32.Types
+import System.X509.Common (withOpenSSLCertEnv)
 
 type HCertStore = Ptr Word8
 type PCCERT_Context = Ptr Word8
@@ -51,7 +52,7 @@ certFromContext cctx = do
         cbCertEncodedPos = pbCertEncodedPos + sizeOf (undefined :: Ptr (Ptr BYTE))
 
 getSystemCertificateStore :: IO CertificateStore
-getSystemCertificateStore = do
+getSystemCertificateStore = withOpenSSLCertEnv $ do
     store <- certOpenSystemStore
     when (store == nullPtr) $ error "no store"
     certs <- loop store nullPtr

--- a/x509-system/x509-system.cabal
+++ b/x509-system/x509-system.cabal
@@ -26,6 +26,7 @@ Library
                    , x509 >= 1.6
                    , x509-store >= 1.6.2
   Exposed-modules:   System.X509
+                     System.X509.Common
                      System.X509.Unix
                      System.X509.MacOS
   ghc-options:       -Wall


### PR DESCRIPTION
## Overview

This PR modifies System.X509's `getSystemCertificateStore` method, to favour OpenSSL  environment variables (as used by git, curl, etc) namely:

- `SSL_CERT_FILE`
- `SSL_CERT_DIR`

If `SSL_CERT_FILE` or `SSL_CERT_DIR` values do not exist, previously implemented certificationStore is yielded. 

Order of precedence:

1) `SSL_CERT_FILE` (OpenSSL conventional env name)
2) `SSL_CERT_DIR` (OpenSSL conventional env name)
3) `SYSTEM_CERTIFICATE_PATH` (Unix Only - Existing implementation)

## Testing

Checkout following forked PR, and use  `SSL_CERT_FILE` or `SSL_CERT_DIR` with fossa

```
SSL_CERT_FILE=/some-file.pem fossa-dev analyze ../some-path/
```

## To-do

- [ ] Regression Test on Linux
- [ ] Regression Test on Windows
- [ ] Regression Test on OSX

## Reference

- #118
- [Open SSL CTX Load](https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html)
